### PR TITLE
Re-ordered endEdit() to fix an issue with ng-model-options updateOn: …

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -782,6 +782,14 @@
               if (!inEdit) {
                 return;
               }
+              
+              //sometimes the events can't keep up with the keyboard and grid focus is lost, so always focus
+              //back to grid here. The focus call needs to be before the $destroy and removal of the control,
+              //otherwise ng-model-options of UpdateOn: 'blur' will not work.
+              if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
+                uiGridCtrl.focus();
+              }
+              
               var gridCellContentsEl = angular.element($elm.children()[0]);
               //remove edit element
               editCellScope.$destroy();
@@ -790,11 +798,6 @@
               inEdit = false;
               registerBeginEditEvents();
               $scope.grid.api.core.notifyDataChange( uiGridConstants.dataChange.EDIT );
-              //sometimes the events can't keep up with the keyboard and grid focus is lost, so always focus
-              //back to grid here
-              if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
-                uiGridCtrl.focus();
-              }
             }
 
             function cancelEdit() {


### PR DESCRIPTION
ng-model-options="{ updateOn: 'blur' }" will not work on custom edit templates because the control and scope is destroyed before the focus is moved off. This change will cause the main grid to get focus before the control and scope is destroyed thus allowing blur events on the control to work.
